### PR TITLE
Bugfix and minor simplification of workers

### DIFF
--- a/src/queuemailerl_smtp_sup.erl
+++ b/src/queuemailerl_smtp_sup.erl
@@ -10,5 +10,5 @@ start_link() ->
 
 init([]) ->
     ChildSpec = {queuemailerl_smtp_worker, {queuemailerl_smtp_worker, start_link, []},
-                 transient, 10, worker, [queuemailerl_smtp_worker]},
+                 temporary, 10, worker, [queuemailerl_smtp_worker]},
     {ok, {{simple_one_for_one, 1, 10}, [ChildSpec]}}.


### PR DESCRIPTION
- Change smtp workers to be temporary children to
  prevent them to bring the application down
- Remove the explicit acks, use monitors instead
- Remove the need for the worker to know it's tag